### PR TITLE
Add current command to display currenty logged in account

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ To list accounts:
     * personal
     work
 
+To find current account:
+
+    $ heroku accounts:current
+    personal
+
 To remove an account:
 
     $ heroku accounts:remove personal

--- a/commands/current.js
+++ b/commands/current.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const cli = require('heroku-cli-util')
+const co = require('co')
+const accounts = require('../lib/accounts')
+
+function * run (context, heroku) {
+  var account = accounts.current();
+  if (account) {
+    cli.log(`${account}`)
+  }
+}
+
+module.exports = {
+  topic: 'accounts',
+  command: 'current',
+  run: cli.command(co.wrap(run))
+}

--- a/commands/current.js
+++ b/commands/current.js
@@ -5,7 +5,7 @@ const co = require('co')
 const accounts = require('../lib/accounts')
 
 function * run (context, heroku) {
-  var account = accounts.current();
+  var account = accounts.current()
   if (account) {
     cli.log(`${account}`)
   }

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ exports.topic = {
 exports.commands = [
   require('./commands'),
   require('./commands/add'),
+  require('./commands/current'),
   require('./commands/remove'),
   require('./commands/set')
 ]


### PR DESCRIPTION
This update exposes the `current` method for displaying the currently logged into account. Useful for command line prompts. Much like how we can display which is the current git branch from the prompt, it's handy to quickly see which account is currently in use.
