### PR TITLE
Use ~/.config/heroku/accounts if ~/.heroku does not exist

### DIFF
--- a/lib/accounts.js
+++ b/lib/accounts.js
@@ -7,7 +7,15 @@ const Netrc = require('netrc')
 const YAML = require('yamljs')
 const mkdirp = require('mkdirp')
 
-const basedir = path.join(os.homedir(), '.heroku', 'accounts')
+function configDir() {
+  const legacyDir = path.join(os.homedir(), '.heroku')
+  if (fs.existsSync(legacyDir)) {
+    return legacyDir
+  }
+  return path.join(os.homedir(), '.config', 'heroku')
+}
+
+const basedir = path.join(configDir(), 'accounts')
 
 const netrcfile = process.platform === 'win32' ? '_netrc' : '.netrc'
 const netrcpath = path.join(os.homedir(), netrcfile)


### PR DESCRIPTION
The heroku command currently uses ~/.config/heroku for storing configuration, so why not make heroku-accounts follow that?