### PR TITLE
Add token command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Helps use multiple accounts on Heroku.
 
 ## Installation
 
-    $ heroku plugins:install heroku-accounts
+    $ heroku plugins:install https://github.com/icheko/heroku-accounts
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ To find current account:
     $ heroku accounts:current
     personal
 
+To print account api token:
+
+    $ heroku accounts:token personal
+    00000000-0000-0000-0000-000000000000
+
+To quickly set the HEROKU_API_KEY environment variable:
+
+    $ heroku accounts:token personal --bash
+
 To remove an account:
 
     $ heroku accounts:remove personal

--- a/commands/token.js
+++ b/commands/token.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const cli = require('heroku-cli-util')
+const co = require('co')
+const accounts = require('../lib/accounts')
+
+function * run (context, heroku) {
+  const {name} = context.args
+  if (!accounts.list().find(a => a.name === name)) {
+    cli.error(`${name} does not exist`)
+    cli.exit(1)
+  }
+
+  accounts.token(name, context.flags.bash)
+}
+
+module.exports = {
+  topic: 'accounts',
+  command: 'token',
+  args: [{name: 'name'}],
+  flags: [{name: 'bash', description: 'shortcut to set HEROKU_API_KEY env variable'}],
+  run: cli.command(co.wrap(run))
+}

--- a/index.js
+++ b/index.js
@@ -10,5 +10,6 @@ exports.commands = [
   require('./commands/add'),
   require('./commands/current'),
   require('./commands/remove'),
-  require('./commands/set')
+  require('./commands/set'),
+  require('./commands/token')
 ]

--- a/lib/accounts.js
+++ b/lib/accounts.js
@@ -6,6 +6,8 @@ const path = require('path')
 const Netrc = require('netrc')
 const YAML = require('yamljs')
 const mkdirp = require('mkdirp')
+const cli = require('heroku-cli-util')
+const clipboard = require('clipboardy')
 
 function configDir () {
   const legacyDir = path.join(os.homedir(), '.heroku')
@@ -76,10 +78,21 @@ function set (name) {
   fs.writeFileSync(netrcpath, data)
 }
 
+function token (name, bashCmd) {
+  let current = account(name)
+  if (bashCmd) {
+    cli.log('Command copied to clipboard. Paste to execute.')
+    clipboard.writeSync('export HEROKU_API_KEY=' + current.password)
+    return null
+  }
+  cli.log(current.password)
+}
+
 module.exports = {
   add,
   current,
   list,
   remove,
-  set
+  set,
+  token
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "heroku-accounts",
   "description": "manage multiple heroku accounts",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "author": "Jeff Dickey @dickeyxxx",
   "bugs": "https://github.com/heroku/heroku-accounts/issues",
   "files": [
@@ -10,6 +10,7 @@
     "/lib"
   ],
   "dependencies": {
+    "clipboardy": "^2.1.0",
     "co": "4.6.0",
     "heroku-cli-util": "^8.0.10",
     "mkdirp": "0.5.1",


### PR DESCRIPTION
Like the auth:token but for all the accounts loaded via this plugin. Also adds a `--bash` flag to quickly set the HEROKU_API_KEY environment variable (Shortcut for #15).