### PR TITLE
fix: make sure to parse the yaml file not the path

### DIFF
--- a/lib/accounts.js
+++ b/lib/accounts.js
@@ -6,7 +6,6 @@ const os = require('os')
 const path = require('path')
 const Netrc = require('netrc')
 
-
 function configDir () {
   const legacyDir = path.join(os.homedir(), '.heroku')
   if (fs.existsSync(legacyDir)) {

--- a/lib/accounts.js
+++ b/lib/accounts.js
@@ -6,6 +6,7 @@ const os = require('os')
 const path = require('path')
 const Netrc = require('netrc')
 
+
 function configDir () {
   const legacyDir = path.join(os.homedir(), '.heroku')
   if (fs.existsSync(legacyDir)) {
@@ -21,7 +22,8 @@ const netrcpath = path.join(os.homedir(), netrcfile)
 const netrc = Netrc(netrcpath)
 
 function account (name) {
-  const account = YAML.parse(path.join(basedir, name))
+  const file = fs.readFileSync(path.join(basedir, name), "utf8");
+  const account = YAML.parse(file);
   if (account[':username']) {
     // convert from ruby symbols
     account.username = account[':username']


### PR DESCRIPTION
I am not aware of why but upon looking at some issues raised such as #50, I had an issue using the plugin. Looking at the code, it seemed that the YAML parser wasn't actually parsing YAML but the name of files? This fixed the issue